### PR TITLE
fix: google sheets export doesn't work when google account language isn't English

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -660,11 +660,11 @@ export default defineBackground(() => {
 
       // Update values in the sheet first
       await makeRequest(
-        `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/Sheet1!A1:append?valueInputOption=USER_ENTERED`,
+        `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/A1:append?valueInputOption=USER_ENTERED`,
         {
           method: 'POST',
           body: JSON.stringify({
-            range: 'Sheet1!A1',
+            range: 'A1',
             majorDimension: 'ROWS',
             values,
           }),


### PR DESCRIPTION
When a user's Google account is set to a language other than English the export function would try to add records to `Sheet1!A1` which doesn't exist since the sheet name is localized.

Found in https://eu.posthog.com/project/63349/replay/0199286e-82a8-7894-a95d-69cdee8bc612?t=56