### PR TITLE
chore: use a personal access token instead of default so the artifact build workflow is triggered

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: node


### PR DESCRIPTION
build workflow is triggered

see: https://github.com/orgs/community/discussions/54574#discussioncomment-10119733