### PR TITLE
fix: keep data table aligned with producing config after column delete

### DIFF
--- a/src/entrypoints/full-data-view/FullDataViewApp.tsx
+++ b/src/entrypoints/full-data-view/FullDataViewApp.tsx
@@ -118,10 +118,14 @@ const FullDataViewApp: React.FC<FullDataViewAppProps> = () => {
                 tabUrl: tab.url || 'Unknown URL',
                 tabTitle: tab.title || 'Unknown Title',
                 scrapeResult: storedData.scrapeResult,
-                config: storedData.currentScrapeConfig || {
-                  mainSelector: '',
-                  columns: [{ name: 'Text', selector: '.' }],
-                },
+                // Prefer the config that produced the data over the current edit-able
+                // config; the data layout (column keys, mainSelector) is only valid in
+                // terms of the producing config.
+                config: storedData.resultProducingConfig ||
+                  storedData.currentScrapeConfig || {
+                    mainSelector: '',
+                    columns: [{ name: 'Text', selector: '.' }],
+                  },
               })
             }
           } catch (err) {

--- a/src/entrypoints/sidepanel/SidePanel.tsx
+++ b/src/entrypoints/sidepanel/SidePanel.tsx
@@ -837,7 +837,7 @@ const SidePanel: React.FC<SidePanelProps> = ({ debugMode, onDebugModeChange }) =
                   <h2 className="text-2xl font-bold">Extracted Data</h2>
                   <ExportButtons
                     scrapeResult={scrapeResult}
-                    config={config}
+                    config={resultProducingConfig || config}
                     showEmptyRows={showEmptyRows}
                     filename={exportFilename}
                     variant="outline"
@@ -846,7 +846,7 @@ const SidePanel: React.FC<SidePanelProps> = ({ debugMode, onDebugModeChange }) =
                 <DataTable
                   data={scrapeResult.data || []}
                   onRowHighlight={handleRowHighlight}
-                  config={config}
+                  config={resultProducingConfig || config}
                   columnOrder={scrapeResult.columnOrder}
                   showEmptyRows={showEmptyRows}
                   onShowEmptyRowsChange={setShowEmptyRows}

--- a/tests/e2e/column-delete.spec.ts
+++ b/tests/e2e/column-delete.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test, TestHelpers } from './fixtures'
+
+/**
+ * Regression test for column-delete index bug.
+ *
+ * Background: when scraping a table the auto-generated config assigns synthetic keys
+ * (col1, col2, col3, ...) to each column. The scraped data is keyed by those synthetic
+ * keys. If the user later deletes a column from the config, the *current* config is
+ * shorter than the data, but the saved scrapeResult and its column order are unchanged.
+ * The data display logic must keep using the producing config (the one that produced the
+ * data) for index lookups; otherwise data shifts under the headers.
+ */
+
+const TABLE_PAGE_URL = 'https://example.com/scrape-similar-column-delete/'
+const TABLE_HTML = `<!doctype html>
+<html>
+  <head><title>Column Delete Regression</title></head>
+  <body>
+    <table>
+      <thead>
+        <tr><th>Alpha</th><th>Beta</th><th>Gamma</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>a1</td><td>b1</td><td>c1</td></tr>
+        <tr><td>a2</td><td>b2</td><td>c2</td></tr>
+      </tbody>
+    </table>
+  </body>
+</html>`
+
+test.describe('Column delete preserves data alignment', () => {
+  test('table data stays aligned with headers after deleting a middle column', async ({
+    openSidePanel,
+    serviceWorker,
+    context,
+  }) => {
+    const sidePanel = await openSidePanel()
+    await TestHelpers.dismissAnalyticsConsent(serviceWorker)
+
+    // Serve a deterministic table at a real https URL via Playwright route mocking
+    const testPage = await context.newPage()
+    await testPage.route(TABLE_PAGE_URL, (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: TABLE_HTML }),
+    )
+    await testPage.goto(TABLE_PAGE_URL)
+    await testPage.bringToFront()
+
+    // Configure selector targeting the data rows and let auto-generate produce the
+    // table-shaped config (synthetic col1/col2/col3 keys with `*[i]` selectors).
+    const mainSelector = sidePanel.locator('#mainSelector')
+    await mainSelector.fill('//tbody/tr')
+    await mainSelector.press('Enter')
+    await sidePanel
+      .getByRole('button', { name: /auto-generate configuration from selector/i })
+      .click()
+
+    // Wait for the selector match-count badge before scraping
+    const countBadge = sidePanel.locator('[data-slot="badge"]').filter({ hasText: /^\d+$/ })
+    await expect(countBadge).toBeVisible()
+
+    // Scrape and wait for the data table to appear
+    await sidePanel.getByRole('button', { name: /^scrape$/i }).click()
+    await expect(sidePanel.getByRole('heading', { name: /extracted data/i })).toBeVisible({
+      timeout: 10000,
+    })
+
+    // Locate the data table (excluding any other tables, e.g. inside the sidepanel)
+    const dataTable = sidePanel.locator('.data-table-container table').first()
+    const headerCells = dataTable.locator('thead th')
+    const firstDataRow = dataTable.locator('tbody tr').first()
+    const firstRowCells = firstDataRow.locator('td')
+
+    // Headers: index 0 = "#", index 1 = "Actions", indexes 2..4 = the data columns.
+    await expect(headerCells.nth(2)).toHaveText('Alpha')
+    await expect(headerCells.nth(3)).toHaveText('Beta')
+    await expect(headerCells.nth(4)).toHaveText('Gamma')
+
+    await expect(firstRowCells.nth(2)).toHaveText('a1')
+    await expect(firstRowCells.nth(3)).toHaveText('b1')
+    await expect(firstRowCells.nth(4)).toHaveText('c1')
+
+    // Delete the middle column ("Beta") from the config form. Buttons are rendered
+    // in column order, so index 1 corresponds to Beta.
+    const removeColumnButtons = sidePanel.getByRole('button', { name: 'Remove column' })
+    await removeColumnButtons.nth(1).click()
+
+    // Until the user re-scrapes, the data table must continue to render the data using
+    // the producing config — otherwise indexes shift and column "Beta" would show
+    // Gamma's value while "Gamma" would render empty.
+    await expect(headerCells.nth(2)).toHaveText('Alpha')
+    await expect(headerCells.nth(3)).toHaveText('Beta')
+    await expect(headerCells.nth(4)).toHaveText('Gamma')
+
+    await expect(firstRowCells.nth(2)).toHaveText('a1')
+    await expect(firstRowCells.nth(3)).toHaveText('b1')
+    await expect(firstRowCells.nth(4)).toHaveText('c1')
+  })
+})


### PR DESCRIPTION
## Summary

- After scraping a table, deleting a column from the config caused every column past the deletion to display the wrong value (e.g. header "Beta" showed Gamma's data, "Gamma" went empty). Headers came from `scrapeResult.columnOrder` (producing config) but data lookups indexed into the now-shorter current `config.columns` to derive keys, so indices shifted.
- Fix: feed `resultProducingConfig || config` to `DataTable` and `ExportButtons` in the side panel, and prefer `resultProducingConfig` over `currentScrapeConfig` when loading tabs in the full data view. The producing config is the only authoritative descriptor of the data layout.
- The misalignment also affected exports (CSV/XLSX/Sheets/clipboard) since they used the same broken `getColumnKeys(columnOrder, config.columns)` pairing.

## Test plan

- [x] New e2e regression test (`tests/e2e/column-delete.spec.ts`) serves a deterministic 3-column table via Playwright route mocking, scrapes it, deletes the middle column, and asserts headers and values stay aligned. Verified to fail on unfixed code (`Expected "b1", Received "c1"`) and pass after the fix.
- [x] `pnpm test` — 185/185 unit tests pass.
- [x] `tests/e2e/full-data-view.spec.ts` — 18/18 pass (touched file).
- [x] `tests/e2e/sidepanel-full-data-view-integration.spec.ts` — 9/9 pass.
- [ ] Manual: scrape a real-world table, delete a middle column, confirm data table still aligned and the existing "rescrape advised" hint shows.